### PR TITLE
Directory and file name casing update

### DIFF
--- a/Source/XStaticCore/XStatic.Core/XStatic.Core.csproj
+++ b/Source/XStaticCore/XStatic.Core/XStatic.Core.csproj
@@ -6,7 +6,7 @@
     <Product>xStatic.Core</Product>
     <PackageId>xStatic.Core</PackageId>
     <Title>xStatic.Core</Title>
-    <Version>3.0.0-beta</Version>
+    <Version>3.0.1-beta</Version>
     <Description>xStatic core libraries used for creating custom components to use with xStatic for Umbraco 9+.</Description>
     <PackageTags>umbraco umbraco9 xstatic static site generation</PackageTags>
     <Authors>Sam Mullins</Authors>

--- a/Source/XStaticCore/XStatic.Ftp/XStatic.Ftp.csproj
+++ b/Source/XStaticCore/XStatic.Ftp/XStatic.Ftp.csproj
@@ -5,7 +5,7 @@
       <Product>xStatic.Ftp</Product>
       <PackageId>xStatic.Ftp</PackageId>
       <Title>xStatic.Ftp</Title>
-      <Version>3.0.0-beta</Version>
+      <Version>3.0.1-beta</Version>
       <Description>FTP functionality for xStatic for Umbraco.</Description>
       <PackageTags>umbraco umbraco9 xstatic static site generation ftp</PackageTags>
       <Copyright>Sam Mullins</Copyright>

--- a/Source/XStaticCore/XStatic.Git/XStatic.Git.csproj
+++ b/Source/XStaticCore/XStatic.Git/XStatic.Git.csproj
@@ -5,7 +5,7 @@
       <Product>xStatic.Git</Product>
       <PackageId>xStatic.Git</PackageId>
       <Title>xStatic.Git</Title>
-      <Version>3.0.0-beta</Version>
+      <Version>3.0.1-beta</Version>
       <Description>Git functionality for xStatic for Umbraco.</Description>
       <PackageTags>umbraco umbraco9 xstatic static site generation git</PackageTags>
       <Copyright>Sam Mullins</Copyright>

--- a/Source/XStaticCore/XStatic.Netlify/XStatic.Netlify.csproj
+++ b/Source/XStaticCore/XStatic.Netlify/XStatic.Netlify.csproj
@@ -5,7 +5,7 @@
     <Product>xStatic.Netlify</Product>
     <PackageId>xStatic.Netlify</PackageId>
     <Title>xStatic.Netlify</Title>
-    <Version>3.0.0-beta</Version>
+    <Version>3.0.1-beta</Version>
     <Description>Netlify functionality for xStatic for Umbraco.</Description>
     <PackageTags>umbraco umbraco9 xstatic static site generation netlify</PackageTags>
     <Copyright>Sam Mullins</Copyright>

--- a/Source/XStaticCore/XStatic/XStatic.csproj
+++ b/Source/XStaticCore/XStatic/XStatic.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <ContentTargetFolders>.</ContentTargetFolders>
@@ -37,40 +37,6 @@
             <Pack>True</Pack>
             <PackagePath>buildTransitive</PackagePath>
         </None>
-    </ItemGroup>
-
-    <ItemGroup>
-      <Content Remove="App_Plugins\xStatic\fields\htmlpage.html" />
-      <Content Remove="App_Plugins\xStatic\fields\mediapicker.html" />
-      <Content Remove="App_Plugins\xStatic\fields\mediapicker.js" />
-      <Content Remove="App_Plugins\xStatic\xStatic\css\xStatic.css" />
-      <Content Remove="App_Plugins\xStatic\xStatic\dashboards\ConfigDashboard.html" />
-      <Content Remove="App_Plugins\xStatic\xStatic\dashboards\ConfigDashboard.js" />
-      <Content Remove="App_Plugins\xStatic\xStatic\dashboards\ExportTypeForm.html" />
-      <Content Remove="App_Plugins\xStatic\xStatic\dashboards\Form.html" />
-      <Content Remove="App_Plugins\xStatic\xStatic\dashboards\MainDashboard.html" />
-      <Content Remove="App_Plugins\xStatic\xStatic\dashboards\MainDashboard.js" />
-      <Content Remove="App_Plugins\xStatic\xStatic\fields\DeploymentTargetField.css" />
-      <Content Remove="App_Plugins\xStatic\xStatic\fields\DeploymentTargetField.html" />
-      <Content Remove="App_Plugins\xStatic\xStatic\fields\DeploymentTargetField.js" />
-      <Content Remove="App_Plugins\xStatic\xStatic\fields\ExportTypeField.html" />
-      <Content Remove="App_Plugins\xStatic\xStatic\fields\ExportTypeField.js" />
-      <Content Remove="App_Plugins\xStatic\xStatic\fields\htmlpage.html" />
-      <Content Remove="App_Plugins\xStatic\xStatic\fields\mediapicker.html" />
-      <Content Remove="App_Plugins\xStatic\xStatic\fields\mediapicker.js" />
-      <Content Remove="App_Plugins\xStatic\xStatic\fields\multipicker.html" />
-      <Content Remove="App_Plugins\xStatic\xStatic\fields\multipicker.js" />
-      <Content Remove="App_Plugins\xStatic\xStatic\fields\TypeField.html" />
-      <Content Remove="App_Plugins\xStatic\xStatic\fields\TypeField.js" />
-      <Content Remove="App_Plugins\xStatic\xStatic\lang\en-GB.xml" />
-      <Content Remove="App_Plugins\xStatic\xStatic\lang\en-US.xml" />
-      <Content Remove="App_Plugins\xStatic\xStatic\package.manifest" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <None Remove="App_Plugins\xStatic\fields\Text.html" />
-      <None Remove="App_Plugins\xStatic\xStatic\fields\Text.html" />
-      <None Remove="App_Plugins\xStatic\xStatic\xStaticConfig.json" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Source/XStaticCore/XStatic/XStatic.csproj
+++ b/Source/XStaticCore/XStatic/XStatic.csproj
@@ -5,7 +5,7 @@
         <Product>xStatic</Product>
         <PackageId>xStatic</PackageId>
         <Title>xStatic</Title>
-        <Version>3.0.0-beta</Version>
+        <Version>3.0.1-beta</Version>
         <Description>Static site generation for Umbraco 9+ without changing the method of building Umbraco sites.</Description>
         <PackageTags>umbraco umbraco9 xstatic static site generation</PackageTags>
         <Copyright>Sam Mullins</Copyright>

--- a/Source/XStaticCore/XStatic/build/XStatic.targets
+++ b/Source/XStaticCore/XStatic/build/XStatic.targets
@@ -1,7 +1,7 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
     <PropertyGroup>
-        <XStaticContentFilesPath>$(MSBuildThisFileDirectory)..\App_Plugins\XStatic\**\*.*</XStaticContentFilesPath>
+        <XStaticContentFilesPath>$(MSBuildThisFileDirectory)..\App_Plugins\xStatic\**\*.*</XStaticContentFilesPath>
     </PropertyGroup>
 
     <Target Name="CopyXStaticAssets" BeforeTargets="Build">
@@ -11,16 +11,16 @@
         <Message Text="Copying XStatic files: $(XStaticContentFilesPath) - #@(XStaticContentFiles->Count()) files"  Importance="high" />
         <Copy
             SourceFiles="@(XStaticContentFiles)"
-            DestinationFiles="@(XStaticContentFiles->'$(MSBuildProjectDirectory)\App_Plugins\XStatic\%(RecursiveDir)%(Filename)%(Extension)')"
+            DestinationFiles="@(XStaticContentFiles->'$(MSBuildProjectDirectory)\App_Plugins\xStatic\%(RecursiveDir)%(Filename)%(Extension)')"
             SkipUnchangedFiles="true" />
 
     </Target>
 
     <Target Name="ClearXStaticAssets" BeforeTargets="Clean">
         <ItemGroup>
-            <XStaticDir Include="$(MSBuildProjectDirectory)\App_Plugins\XStatic\" />
+            <XStaticDir Include="$(MSBuildProjectDirectory)\App_Plugins\xStatic\" />
         </ItemGroup>
-        <Message Text="Clear old XStatic data"  Importance="high" />
+        <Message Text="Clear old xStatic data"  Importance="high" />
         <RemoveDir Directories="@(XStaticDir)"  />
     </Target>
 


### PR DESCRIPTION
This pull request addresses the issue that I ran into regarding a casing issue for a non-Windows, case-sensitive environment.  Only one file exhibited an inconsistency with regards to "XStatic" versus the desired "xStatic" and that is the updated file 'XStaticCore/XStatic/build/XStatic.targets'.  This file has been updated with the desired "xStatic" directory name.

This pull request also addresses a small issue that I discovered in my testing where a few content files in the 'App_Plugins\Fields' directory were missing.  While testing, the minification of these resource files revealed that the 'mediapicker.html' and 'mediapicker.js' files did not make it into the package.  I made an adjustment to the 'XStatic.csproj' file with regards to the 'App_Plugins' directory and I'm now seeing these files incorporated in the nuget package.

Additionally, the csproj package versions were bumped to _3.0.1-beta_.

**Testing**
A local Umbraco v10.2.1 (Windows environment) instance with the Umbraco.TheStarterKit installed and confirmed all worked as expected.

A Linux Azure App Service was created with the Umbraco v10.2.1 instance deployed to it.  Reviewing the backoffice, I can confirm that the xStatic dashboards are coming through in this environment and that the minification of the backoffice resource files is not experiencing any issues.