### PR TITLE
Fix/linux system pathing

### DIFF
--- a/Source/XStaticCore/XStatic/Controllers/DownloadController.cs
+++ b/Source/XStaticCore/XStatic/Controllers/DownloadController.cs
@@ -39,7 +39,7 @@ namespace XStatic.Controllers
                 throw new FileNotFoundException();
             }
 
-            var localZipFilePath = localFolderPath.Trim('/').Trim('\\') + ".zip";
+            var localZipFilePath = localFolderPath.TrimEnd(new char[]  { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar }) + ".zip";
 
             if (System.IO.File.Exists(localZipFilePath))
             {


### PR DESCRIPTION
This update is intended to address the recent issue that was opened #17 

I've made small code updates to XStatic.Core/Generator/Storage/AppDataSiteStorer.cs and XStatic/Controllers/DownloadController.cs to resolve the issue being seen with file paths in Linux environments but continue to work within a Window environment.

The nature of the fixes has mostly come down to the Path.IsPathRooted check within the FileHelpers.PathCombine method.  Within the Linux environment, full paths were being concatenated to the rooted path yielding an unexpected path several levels deeper.

The update has been tested in the following environments:

For Linux:
- Debian (WSL)
- Debian (Azure App Service)

For Windows:
- Windows 10 (Local development)
- App Service (Azure App Service)

The tests consisted of taking an Umbraco 10.2.1 site with the Umbraco.TheStarterKit installed and included project references from the XStatic solution's individual projects.  The xStatic.AWSS3 project was also included.

2 test static sites were created - 1 with FTP deployment and 1 with AWS S3 deployment.  The projects were successfully built, deployed and downloaded in each of the environments.

The Azure App Service environments are available for review if you are interested.

Please let me know if there's any further updates that you would like to see contained within this update.

Thank you!

