### PR TITLE
Feature: Custom output folder name (follow on)

### DIFF
--- a/Source/XStaticCore/XStatic.Core/App/GeneratorServiceBuilder.cs
+++ b/Source/XStaticCore/XStatic.Core/App/GeneratorServiceBuilder.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using XStatic.Core.Actions;
 using XStatic.Core.Actions.FileActions;
@@ -81,6 +83,18 @@ namespace XStatic.Core.App
         public GeneratorServiceBuilder AddDefaultSiteStorageServices()
         {
             _services.AddSingleton<IStaticSiteStorer, AppDataSiteStorer>();
+
+            return this;
+        }
+
+        public GeneratorServiceBuilder AddCustomDefinedSingleSiteStorer(string outputFolderName)
+        {
+            _services.AddSingleton<IStaticSiteStorer>(serviceProvider =>
+            {
+                var webHostEnvironment = serviceProvider.GetRequiredService<IWebHostEnvironment>();
+                var logger = serviceProvider.GetRequiredService<ILogger<IStaticSiteStorer>>();
+                return new CustomDefinedSingleSiteStorer(webHostEnvironment, logger, outputFolderName);
+            });
 
             return this;
         }

--- a/Source/XStaticCore/XStatic.Core/App/GeneratorServiceBuilder.cs
+++ b/Source/XStaticCore/XStatic.Core/App/GeneratorServiceBuilder.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using XStatic.Core.Actions;
 using XStatic.Core.Actions.FileActions;
@@ -78,9 +80,14 @@ namespace XStatic.Core.App
             return this;
         }
 
-        public GeneratorServiceBuilder AddDefaultSiteStorageServices()
+        public GeneratorServiceBuilder AddDefaultSiteStorageServices(string outputFolderName = null)
         {
-            _services.AddSingleton<IStaticSiteStorer, AppDataSiteStorer>();
+            _services.AddSingleton<IStaticSiteStorer>(serviceProvider =>
+            {
+                var webHostEnvironment = serviceProvider.GetRequiredService<IWebHostEnvironment>();
+                var logger = serviceProvider.GetRequiredService<ILogger<IStaticSiteStorer>>();
+                return new AppDataSiteStorer(webHostEnvironment, logger, outputFolderName);
+            });
 
             return this;
         }
@@ -102,7 +109,7 @@ namespace XStatic.Core.App
             return this;
         }
 
-        public GeneratorServiceBuilder AddDefaults()
+        public GeneratorServiceBuilder AddDefaults(string outputFolderName = null)
         {
             return AddDefaultSiteRepository()
                 .AddDefaultComponentLists()
@@ -113,7 +120,7 @@ namespace XStatic.Core.App
                 .AddDefaultJsonGeneratorServices()
                 .AddDefaultImageCropServices()
                 .AddDefaultAutoDeployServices()
-                .AddDefaultSiteStorageServices();
+                .AddDefaultSiteStorageServices(outputFolderName);
         }
 
         public void Build()

--- a/Source/XStaticCore/XStatic.Core/App/GeneratorServiceBuilder.cs
+++ b/Source/XStaticCore/XStatic.Core/App/GeneratorServiceBuilder.cs
@@ -1,6 +1,4 @@
-using Microsoft.AspNetCore.Hosting;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.Extensions.DependencyInjection;
 using System.Collections.Generic;
 using XStatic.Core.Actions;
 using XStatic.Core.Actions.FileActions;
@@ -80,14 +78,9 @@ namespace XStatic.Core.App
             return this;
         }
 
-        public GeneratorServiceBuilder AddDefaultSiteStorageServices(string outputFolderName = null)
+        public GeneratorServiceBuilder AddDefaultSiteStorageServices()
         {
-            _services.AddSingleton<IStaticSiteStorer>(serviceProvider =>
-            {
-                var webHostEnvironment = serviceProvider.GetRequiredService<IWebHostEnvironment>();
-                var logger = serviceProvider.GetRequiredService<ILogger<IStaticSiteStorer>>();
-                return new AppDataSiteStorer(webHostEnvironment, logger, outputFolderName);
-            });
+            _services.AddSingleton<IStaticSiteStorer, AppDataSiteStorer>();
 
             return this;
         }
@@ -109,7 +102,7 @@ namespace XStatic.Core.App
             return this;
         }
 
-        public GeneratorServiceBuilder AddDefaults(string outputFolderName = null)
+        public GeneratorServiceBuilder AddDefaults()
         {
             return AddDefaultSiteRepository()
                 .AddDefaultComponentLists()
@@ -120,7 +113,7 @@ namespace XStatic.Core.App
                 .AddDefaultJsonGeneratorServices()
                 .AddDefaultImageCropServices()
                 .AddDefaultAutoDeployServices()
-                .AddDefaultSiteStorageServices(outputFolderName);
+                .AddDefaultSiteStorageServices();
         }
 
         public void Build()

--- a/Source/XStaticCore/XStatic.Core/App/GeneratorServiceBuilder.cs
+++ b/Source/XStaticCore/XStatic.Core/App/GeneratorServiceBuilder.cs
@@ -87,7 +87,7 @@ namespace XStatic.Core.App
             return this;
         }
 
-        public GeneratorServiceBuilder AddCustomDefinedSingleSiteStorer(string outputFolderName)
+        public GeneratorServiceBuilder AddSingleSiteStorageServices(string outputFolderName)
         {
             _services.AddSingleton<IStaticSiteStorer>(serviceProvider =>
             {
@@ -128,6 +128,20 @@ namespace XStatic.Core.App
                 .AddDefaultImageCropServices()
                 .AddDefaultAutoDeployServices()
                 .AddDefaultSiteStorageServices();
+        }
+
+        public GeneratorServiceBuilder AddSingleSiteDefaults(string folderName)
+        {
+            return AddDefaultSiteRepository()
+                .AddDefaultComponentLists()
+                .AddDefaultExportTypeServices()
+                .AddDefaultActionServices()
+                .AddDefaultActions()
+                .AddDefaultHtmlGeneratorServices()
+                .AddDefaultJsonGeneratorServices()
+                .AddDefaultImageCropServices()
+                .AddDefaultAutoDeployServices()
+                .AddSingleSiteStorageServices(folderName);
         }
 
         public void Build()

--- a/Source/XStaticCore/XStatic.Core/App/XStaticApp.cs
+++ b/Source/XStaticCore/XStatic.Core/App/XStaticApp.cs
@@ -1,6 +1,8 @@
-﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.DependencyInjection;
+using System.Linq;
 using Umbraco.Cms.Core.Services;
+using XStatic.Core.Generator.Storage;
 
 namespace XStatic.Core.App
 {
@@ -71,6 +73,27 @@ namespace XStatic.Core.App
             {
                 settings.TrustSslWhenGenerating = true;
             });
+
+            return this;
+        }
+
+        /// <summary>
+        /// When used, it will add the <see cref="CustomDefinedSingleSiteStorer"/>, which provides custom output folder
+        /// naming. It also removes the default <see cref="AppDataSiteStorer"/>.
+        /// </summary>
+        /// <returns></returns>
+        public XStaticServiceBuilder UseSingleSiteOutput(string outpuFolderName = "DefaultOutputFolder")
+        {
+            var descriptor = _services.FirstOrDefault(services =>
+                services.ServiceType == typeof(IStaticSiteStorer) &&
+                services.ImplementationType == typeof(AppDataSiteStorer));
+
+            if (descriptor != null)
+            {
+                _services.Remove(descriptor);
+            }
+
+            GeneratorServiceBuilder.AddCustomDefinedSingleSiteStorer(outpuFolderName);
 
             return this;
         }

--- a/Source/XStaticCore/XStatic.Core/App/XStaticApp.cs
+++ b/Source/XStaticCore/XStatic.Core/App/XStaticApp.cs
@@ -31,6 +31,20 @@ namespace XStatic.Core.App
         }
 
         /// <summary>
+        /// When used, it will add the <see cref="CustomDefinedSingleSiteStorer"/>, which provides custom output folder
+        /// naming. It also removes the default <see cref="AppDataSiteStorer"/>.
+        /// </summary>
+        /// <returns></returns>
+        public XStaticServiceBuilder AutomaticWithSingleSiteOutput(string outputFolderName = "DefaultOutputFolder")
+        {
+            GeneratorServiceBuilder.AddSingleSiteDefaults(outputFolderName);
+            DeployServiceBuilder.AddDeployersAutomatically();
+            DeployServiceBuilder.AddDeploymentTargetCreatorsAutomatically();
+
+            return this;
+        }
+
+        /// <summary>
         /// This adds two roles and turns on secure user groups so that only specified users can access private data like API keys.
         /// </summary>
         /// <param name="adminUserToCreateRoles">This is likely to be the email of the user</param>
@@ -73,27 +87,6 @@ namespace XStatic.Core.App
             {
                 settings.TrustSslWhenGenerating = true;
             });
-
-            return this;
-        }
-
-        /// <summary>
-        /// When used, it will add the <see cref="CustomDefinedSingleSiteStorer"/>, which provides custom output folder
-        /// naming. It also removes the default <see cref="AppDataSiteStorer"/>.
-        /// </summary>
-        /// <returns></returns>
-        public XStaticServiceBuilder UseSingleSiteOutput(string outpuFolderName = "DefaultOutputFolder")
-        {
-            var descriptor = _services.FirstOrDefault(services =>
-                services.ServiceType == typeof(IStaticSiteStorer) &&
-                services.ImplementationType == typeof(AppDataSiteStorer));
-
-            if (descriptor != null)
-            {
-                _services.Remove(descriptor);
-            }
-
-            GeneratorServiceBuilder.AddCustomDefinedSingleSiteStorer(outpuFolderName);
 
             return this;
         }

--- a/Source/XStaticCore/XStatic.Core/App/XStaticApp.cs
+++ b/Source/XStaticCore/XStatic.Core/App/XStaticApp.cs
@@ -1,4 +1,4 @@
-using Microsoft.CodeAnalysis.CSharp.Syntax;
+﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.Services;
 
@@ -19,9 +19,9 @@ namespace XStatic.Core.App
             DeployServiceBuilder = new DeployServiceBuilder(_services);
         }
 
-        public XStaticServiceBuilder Automatic(string outputFolderName = null)
+        public XStaticServiceBuilder Automatic()
         {
-            GeneratorServiceBuilder.AddDefaults(outputFolderName);
+            GeneratorServiceBuilder.AddDefaults();
             DeployServiceBuilder.AddDeployersAutomatically();
             DeployServiceBuilder.AddDeploymentTargetCreatorsAutomatically();
 

--- a/Source/XStaticCore/XStatic.Core/App/XStaticApp.cs
+++ b/Source/XStaticCore/XStatic.Core/App/XStaticApp.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.DependencyInjection;
 using Umbraco.Cms.Core.Services;
 
@@ -19,9 +19,9 @@ namespace XStatic.Core.App
             DeployServiceBuilder = new DeployServiceBuilder(_services);
         }
 
-        public XStaticServiceBuilder Automatic()
+        public XStaticServiceBuilder Automatic(string outputFolderName = null)
         {
-            GeneratorServiceBuilder.AddDefaults();
+            GeneratorServiceBuilder.AddDefaults(outputFolderName);
             DeployServiceBuilder.AddDeployersAutomatically();
             DeployServiceBuilder.AddDeploymentTargetCreatorsAutomatically();
 

--- a/Source/XStaticCore/XStatic.Core/Generator/Storage/AppDataSiteStorer.cs
+++ b/Source/XStaticCore/XStatic.Core/Generator/Storage/AppDataSiteStorer.cs
@@ -1,5 +1,6 @@
-﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Logging;
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using XStatic.Core.Helpers;
@@ -11,14 +12,17 @@ namespace XStatic.Core.Generator.Storage
         private readonly IWebHostEnvironment _hostingEnvironment;
         private readonly ILogger<IStaticSiteStorer> _logger;
         private readonly string _xStaticPublishRoot;
+        private readonly string _outputFolderName;
 
-        public AppDataSiteStorer(IWebHostEnvironment hostingEnvironment, ILogger<IStaticSiteStorer> logger)
+        public AppDataSiteStorer(IWebHostEnvironment hostingEnvironment, ILogger<IStaticSiteStorer> logger, string outputFolderName = null)
         {
             _hostingEnvironment = hostingEnvironment;
             _logger = logger;
 
             var xStaticRoot = Path.Combine(new string[] { _hostingEnvironment.ContentRootPath, "umbraco", "Data", "xStatic" });
             _xStaticPublishRoot = Path.Combine(new string[] { _hostingEnvironment.ContentRootPath, "umbraco", "Data", "xStatic", "output" });
+
+            _outputFolderName = outputFolderName;
 
             if(!Directory.Exists(xStaticRoot)) Directory.CreateDirectory(xStaticRoot);
             if(!Directory.Exists(_xStaticPublishRoot)) Directory.CreateDirectory(_xStaticPublishRoot);
@@ -28,7 +32,9 @@ namespace XStatic.Core.Generator.Storage
         {
             return TaskHelper.FromResultOf(() =>
             {
-                string storagePath = FileHelpers.PathCombine(_xStaticPublishRoot, subFolder + "/" + path);
+                var finalOutputFolder = string.IsNullOrEmpty(_outputFolderName) ? subFolder : _outputFolderName;
+
+                string storagePath = FileHelpers.PathCombine(_xStaticPublishRoot, finalOutputFolder + "/" + path);
                 var filePath = Path.Combine(_xStaticPublishRoot, storagePath);
 
                 _logger.LogInformation("[StoreSiteItem] storagePath = {storagePath} | filePath = {filePath}", storagePath, filePath);
@@ -111,7 +117,9 @@ namespace XStatic.Core.Generator.Storage
 
         public string GetStorageLocationOfSite(int staticSiteId)
         {
-            string storagePath = FileHelpers.PathCombine(_xStaticPublishRoot, staticSiteId.ToString());            
+            var finalOutputFolder = string.IsNullOrEmpty(_outputFolderName) ? staticSiteId.ToString() : _outputFolderName;
+
+            string storagePath = FileHelpers.PathCombine(_xStaticPublishRoot, finalOutputFolder);
             var folderPath = Path.Combine(_xStaticPublishRoot, storagePath);
 
             _logger.LogInformation("[GetStorageLocationOfSite] storagePath = {storagePath} | folderPath = {folderPath}", storagePath, folderPath);

--- a/Source/XStaticCore/XStatic.Core/Generator/Storage/AppDataSiteStorer.cs
+++ b/Source/XStaticCore/XStatic.Core/Generator/Storage/AppDataSiteStorer.cs
@@ -1,6 +1,5 @@
-using Microsoft.AspNetCore.Hosting;
+﻿using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Logging;
-using System;
 using System.IO;
 using System.Threading.Tasks;
 using XStatic.Core.Helpers;
@@ -12,17 +11,14 @@ namespace XStatic.Core.Generator.Storage
         private readonly IWebHostEnvironment _hostingEnvironment;
         private readonly ILogger<IStaticSiteStorer> _logger;
         private readonly string _xStaticPublishRoot;
-        private readonly string _outputFolderName;
 
-        public AppDataSiteStorer(IWebHostEnvironment hostingEnvironment, ILogger<IStaticSiteStorer> logger, string outputFolderName = null)
+        public AppDataSiteStorer(IWebHostEnvironment hostingEnvironment, ILogger<IStaticSiteStorer> logger)
         {
             _hostingEnvironment = hostingEnvironment;
             _logger = logger;
 
             var xStaticRoot = Path.Combine(new string[] { _hostingEnvironment.ContentRootPath, "umbraco", "Data", "xStatic" });
             _xStaticPublishRoot = Path.Combine(new string[] { _hostingEnvironment.ContentRootPath, "umbraco", "Data", "xStatic", "output" });
-
-            _outputFolderName = outputFolderName;
 
             if(!Directory.Exists(xStaticRoot)) Directory.CreateDirectory(xStaticRoot);
             if(!Directory.Exists(_xStaticPublishRoot)) Directory.CreateDirectory(_xStaticPublishRoot);
@@ -32,9 +28,7 @@ namespace XStatic.Core.Generator.Storage
         {
             return TaskHelper.FromResultOf(() =>
             {
-                var finalOutputFolder = string.IsNullOrEmpty(_outputFolderName) ? subFolder : _outputFolderName;
-
-                string storagePath = FileHelpers.PathCombine(_xStaticPublishRoot, finalOutputFolder + "/" + path);
+                string storagePath = FileHelpers.PathCombine(_xStaticPublishRoot, subFolder + "/" + path);
                 var filePath = Path.Combine(_xStaticPublishRoot, storagePath);
 
                 _logger.LogInformation("[StoreSiteItem] storagePath = {storagePath} | filePath = {filePath}", storagePath, filePath);
@@ -117,9 +111,7 @@ namespace XStatic.Core.Generator.Storage
 
         public string GetStorageLocationOfSite(int staticSiteId)
         {
-            var finalOutputFolder = string.IsNullOrEmpty(_outputFolderName) ? staticSiteId.ToString() : _outputFolderName;
-
-            string storagePath = FileHelpers.PathCombine(_xStaticPublishRoot, finalOutputFolder);
+            string storagePath = FileHelpers.PathCombine(_xStaticPublishRoot, staticSiteId.ToString());            
             var folderPath = Path.Combine(_xStaticPublishRoot, storagePath);
 
             _logger.LogInformation("[GetStorageLocationOfSite] storagePath = {storagePath} | folderPath = {folderPath}", storagePath, folderPath);

--- a/Source/XStaticCore/XStatic.Core/Generator/Storage/CustomDefinedSingleSiteStorer.cs
+++ b/Source/XStaticCore/XStatic.Core/Generator/Storage/CustomDefinedSingleSiteStorer.cs
@@ -12,7 +12,6 @@ namespace XStatic.Core.Generator.Storage
         private readonly IWebHostEnvironment _hostingEnvironment;
         private readonly ILogger<IStaticSiteStorer> _logger;
         private readonly string _xStaticPublishRoot;
-        private readonly string _outputFolderName;
 
         public CustomDefinedSingleSiteStorer(IWebHostEnvironment hostingEnvironment, ILogger<IStaticSiteStorer> logger, string outputFolderName)
         {
@@ -20,9 +19,7 @@ namespace XStatic.Core.Generator.Storage
             _logger = logger;
 
             var xStaticRoot = Path.Combine(new string[] { _hostingEnvironment.ContentRootPath, "umbraco", "Data", "xStatic" });
-            _xStaticPublishRoot = Path.Combine(new string[] { _hostingEnvironment.ContentRootPath, "umbraco", "Data", "xStatic", "output" });
-
-            _outputFolderName = outputFolderName;
+            _xStaticPublishRoot = Path.Combine(new string[] { _hostingEnvironment.ContentRootPath, "umbraco", "Data", "xStatic", "output", outputFolderName });
 
             if(!Directory.Exists(xStaticRoot)) Directory.CreateDirectory(xStaticRoot);
             if(!Directory.Exists(_xStaticPublishRoot)) Directory.CreateDirectory(_xStaticPublishRoot);
@@ -32,7 +29,7 @@ namespace XStatic.Core.Generator.Storage
         {
             return TaskHelper.FromResultOf(() =>
             {
-                string storagePath = FileHelpers.PathCombine(_xStaticPublishRoot, _outputFolderName + "/" + path);
+                string storagePath = FileHelpers.PathCombine(_xStaticPublishRoot, path);
                 var filePath = Path.Combine(_xStaticPublishRoot, storagePath);
 
                 _logger.LogInformation("[StoreSiteItem] storagePath = {storagePath} | filePath = {filePath}", storagePath, filePath);
@@ -103,7 +100,9 @@ namespace XStatic.Core.Generator.Storage
 
         public string GetFileDestinationPath(string subFolder, string partialDestinationPath)
         {
-            string storagePath = FileHelpers.PathCombine(_xStaticPublishRoot, subFolder + "/" + partialDestinationPath);
+            // FYI this ignores the subfolder in single site mode as this will always be the ID of the site.
+
+            string storagePath = FileHelpers.PathCombine(_xStaticPublishRoot, partialDestinationPath);
             var filePath = Path.Combine(_xStaticPublishRoot, storagePath);
 
             var fi = new FileInfo(filePath);
@@ -115,12 +114,7 @@ namespace XStatic.Core.Generator.Storage
 
         public string GetStorageLocationOfSite(int staticSiteId)
         {
-            string storagePath = FileHelpers.PathCombine(_xStaticPublishRoot, _outputFolderName);
-            var folderPath = Path.Combine(_xStaticPublishRoot, storagePath);
-
-            _logger.LogInformation("[GetStorageLocationOfSite] storagePath = {storagePath} | folderPath = {folderPath}", storagePath, folderPath);
-
-            return folderPath;
+            return _xStaticPublishRoot;
         }
     }
 }

--- a/Source/XStaticCore/XStatic.Core/Generator/Storage/CustomDefinedSingleSiteStorer.cs
+++ b/Source/XStaticCore/XStatic.Core/Generator/Storage/CustomDefinedSingleSiteStorer.cs
@@ -1,0 +1,126 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using XStatic.Core.Helpers;
+
+namespace XStatic.Core.Generator.Storage
+{
+    public class CustomDefinedSingleSiteStorer : IStaticSiteStorer
+    {
+        private readonly IWebHostEnvironment _hostingEnvironment;
+        private readonly ILogger<IStaticSiteStorer> _logger;
+        private readonly string _xStaticPublishRoot;
+        private readonly string _outputFolderName;
+
+        public CustomDefinedSingleSiteStorer(IWebHostEnvironment hostingEnvironment, ILogger<IStaticSiteStorer> logger, string outputFolderName)
+        {
+            _hostingEnvironment = hostingEnvironment;
+            _logger = logger;
+
+            var xStaticRoot = Path.Combine(new string[] { _hostingEnvironment.ContentRootPath, "umbraco", "Data", "xStatic" });
+            _xStaticPublishRoot = Path.Combine(new string[] { _hostingEnvironment.ContentRootPath, "umbraco", "Data", "xStatic", "output" });
+
+            _outputFolderName = outputFolderName;
+
+            if(!Directory.Exists(xStaticRoot)) Directory.CreateDirectory(xStaticRoot);
+            if(!Directory.Exists(_xStaticPublishRoot)) Directory.CreateDirectory(_xStaticPublishRoot);
+        }
+
+        public Task<string> StoreSiteItem(string subFolder, string path, string contents, System.Text.Encoding encoding)
+        {
+            return TaskHelper.FromResultOf(() =>
+            {
+                string storagePath = FileHelpers.PathCombine(_xStaticPublishRoot, _outputFolderName + "/" + path);
+                var filePath = Path.Combine(_xStaticPublishRoot, storagePath);
+
+                _logger.LogInformation("[StoreSiteItem] storagePath = {storagePath} | filePath = {filePath}", storagePath, filePath);
+
+                var fi = new FileInfo(filePath);
+                if (fi.Exists) fi.Delete();
+                if (!fi.Directory.Exists) fi.Directory.Create();
+
+                File.WriteAllText(storagePath, contents, encoding);
+
+                _logger.LogInformation("[StoreSiteItem] File.WriteAllText is successful!");
+
+                return filePath;
+            });
+        }
+
+        public Task<string> CopyFile(string subFolder, string sourcePath, string partialDestinationPath)
+        {
+            return TaskHelper.FromResultOf(() =>
+            {
+                var filePath = GetFileDestinationPath(subFolder, partialDestinationPath);
+
+                _logger.LogInformation("[CopyFile] subFolder = {subFolder} | partialDestinationPath = {partialDestinationPath} | filePath = {filePath}", subFolder, partialDestinationPath, filePath);
+
+                File.Copy(sourcePath, filePath);
+
+                _logger.LogInformation("[CopyFile] File.Copy is successful!");
+
+                return filePath;
+            });
+        }
+
+        public Task<string> MoveFile(string subFolder, string sourcePath, string partialDestinationPath)
+        {
+            return TaskHelper.FromResultOf(() =>
+            {
+                var filePath = GetFileDestinationPath(subFolder, partialDestinationPath);
+
+                File.Move(sourcePath, filePath);
+
+                return filePath;
+            });
+        }
+
+        public Task DeleteFile(string sourcePath)
+        {
+            return TaskHelper.FromResultOf(() =>
+            {
+                File.Delete(sourcePath);
+            });
+        }
+
+        public Task<string> SaveFile(string subFolder, Stream stream, string partialDestinationPath)
+        {
+            return TaskHelper.FromResultOf(() =>
+            {
+                var filePath = GetFileDestinationPath(subFolder, partialDestinationPath);
+
+                using (var fileStream = File.Create(filePath))
+                {
+                    stream.Seek(0, SeekOrigin.Begin);
+                    stream.CopyTo(fileStream);
+                }
+
+                return filePath;
+            });
+        }
+
+        public string GetFileDestinationPath(string subFolder, string partialDestinationPath)
+        {
+            string storagePath = FileHelpers.PathCombine(_xStaticPublishRoot, subFolder + "/" + partialDestinationPath);
+            var filePath = Path.Combine(_xStaticPublishRoot, storagePath);
+
+            var fi = new FileInfo(filePath);
+            if (fi.Exists) fi.Delete();
+            if (!fi.Directory.Exists) fi.Directory.Create();
+
+            return filePath;
+        }
+
+        public string GetStorageLocationOfSite(int staticSiteId)
+        {
+            string storagePath = FileHelpers.PathCombine(_xStaticPublishRoot, _outputFolderName);
+            var folderPath = Path.Combine(_xStaticPublishRoot, storagePath);
+
+            _logger.LogInformation("[GetStorageLocationOfSite] storagePath = {storagePath} | folderPath = {folderPath}", storagePath, folderPath);
+
+            return folderPath;
+        }
+    }
+}


### PR DESCRIPTION
This is an edited version of this PR

Fixes https://github.com/Mulliman/xStatic-for-Umbraco/issues/39

This PR adds an option to provide a custom name for the output folder, instead of the default siteId (which usually starts with 1).

The new code doesn't change how Automatic() works, but it adds an optional parameter Automatic(string outputFolderName = null) that will be passed down and used by AppDataSiteStorer.cs if not null.

An additional note, I didn't find this page: https://www.sammullins.co.uk/software/xstatic-for-umbraco/building-your-first-static-site/ in the Readme or Docs, but I wanted to add this new functionality to point 3.