### PR TITLE
⚡ Optimize SitesRepository with parameterized SQL queries

### DIFF
--- a/Source/XStaticCore/XStatic.Core/Repositories/SitesRepository.cs
+++ b/Source/XStaticCore/XStatic.Core/Repositories/SitesRepository.cs
@@ -55,7 +55,7 @@ namespace XStatic.Core.Repositories
         {
             using IScope scope = _scopeProvider.CreateScope();
 
-            var query = new Sql().Select("*").From(SitesTableName).Where("Id = " + staticSiteId);
+            var query = new Sql().Select("*").From(SitesTableName).Where("Id = @0", staticSiteId);
 
             var sites = scope.Database.Fetch<T>(query);
 
@@ -154,7 +154,7 @@ namespace XStatic.Core.Repositories
 
             try
             {
-                var query = new Sql().Select("*").From(SitesTableName).Where("Id = " + staticSiteId);
+                var query = new Sql().Select("*").From(SitesTableName).Where("Id = @0", staticSiteId);
 
                 var entity = scope.Database.Fetch<SiteConfig>(query).FirstOrDefault();
 
@@ -184,7 +184,7 @@ namespace XStatic.Core.Repositories
 
             try
             {
-                var query = new Sql().Select("*").From(SitesTableName).Where("Id = " + staticSiteId);
+                var query = new Sql().Select("*").From(SitesTableName).Where("Id = @0", staticSiteId);
 
                 var entity = scope.Database.Fetch<SiteConfig>(query).FirstOrDefault();
 


### PR DESCRIPTION
This PR replaces unparameterized SQL queries with parameterized ones in `SitesRepository.cs`. Specifically, it updates `Get<T>`, `UpdateLastRun`, and `UpdateLastDeploy` to use `Where("Id = @0", staticSiteId)` instead of string concatenation. This change allows the database engine to cache execution plans for these queries, improving performance under load. It also adheres to security best practices, although the input was already an integer.

Verification:
- A temporary verification project was created to mock the `IScopeProvider` and `IUmbracoDatabase`.
- The verification script confirmed that the original code produced hardcoded SQL (`WHERE (Id = 123)`) and the new code produces parameterized SQL (`WHERE (Id = @0)` with argument `123`).
- The generated SQL syntax is correct for NPoco/Umbraco.

---
*PR created automatically by Jules for task [17050858409954817041](https://jules.google.com/task/17050858409954817041) started by @Mulliman*